### PR TITLE
ci: README manual-block guard

### DIFF
--- a/.github/workflows/readme-guard.yml
+++ b/.github/workflows/readme-guard.yml
@@ -1,0 +1,54 @@
+name: README manual-block guard
+
+# Protects hand-maintained blocks in README.md delimited by
+#   <!-- BEGIN MANUAL: … -->  …  <!-- END MANUAL: … -->
+# On a pull request it fails only if a manual block that exists on the base
+# branch is being removed (marker count drops), so it is a no-op for repos that
+# have no such block yet — and activates automatically once one is added.
+# Mirrors the guard in sanskrit-lexicon/csl-apidev. See COLOGNE#249.
+
+on:
+  pull_request:
+    paths:
+      - README.md
+  workflow_dispatch:
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure no manual block is dropped from README.md
+        run: |
+          base_ref="${{ github.base_ref }}"
+          if [ -z "$base_ref" ]; then
+            echo "Not a pull request; nothing to diff."
+            exit 0
+          fi
+          git fetch --no-tags --depth=1 origin "$base_ref"
+          base_begin=$(git show "origin/$base_ref:README.md" 2>/dev/null | grep -cF '<!-- BEGIN MANUAL:')
+          head_begin=$(grep -cF '<!-- BEGIN MANUAL:' README.md 2>/dev/null || echo 0)
+          base_end=$(git show "origin/$base_ref:README.md" 2>/dev/null | grep -cF '<!-- END MANUAL:')
+          head_end=$(grep -cF '<!-- END MANUAL:' README.md 2>/dev/null || echo 0)
+          echo "base: BEGIN=$base_begin END=$base_end | head: BEGIN=$head_begin END=$head_end"
+          fail=0
+          if [ "$head_begin" -lt "$base_begin" ]; then
+            echo "::error file=README.md::A '<!-- BEGIN MANUAL -->' block present on $base_ref was removed ($base_begin -> $head_begin)."
+            fail=1
+          fi
+          if [ "$head_end" -lt "$base_end" ]; then
+            echo "::error file=README.md::A '<!-- END MANUAL -->' marker present on $base_ref was removed ($base_end -> $head_end)."
+            fail=1
+          fi
+          if [ "$head_begin" -ne "$head_end" ]; then
+            echo "::error file=README.md::Unbalanced manual markers: $head_begin BEGIN vs $head_end END."
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "Hand-maintained README block(s) must not be dropped; restore them and their markers."
+            exit 1
+          fi
+          echo "OK: no manual block removed."


### PR DESCRIPTION
Adds a README manual-block guard, mirroring the one in
[`sanskrit-lexicon/csl-apidev`](https://github.com/sanskrit-lexicon/csl-apidev/blob/master/.github/workflows/readme-guard.yml)
and [`sanskrit-lexicon/mw-dev`](https://github.com/sanskrit-lexicon/mw-dev/blob/main/.github/workflows/readme-guard.yml).

**What it does.** On a pull request that touches `README.md`, it compares against
the base branch and fails **only if a hand-maintained block** delimited by
`<!-- BEGIN MANUAL: … -->` / `<!-- END MANUAL: … -->` markers is being removed (or
left unbalanced). It is a **no-op** for this repo today — there are no manual blocks
yet — and activates automatically the moment one is added.

**Why.** The Cologne Tooling Runbook regenerates `README.md` and is instructed to
preserve marked manual blocks verbatim. This workflow is the CI backstop for any
edit (by a tool or a person) that ignores that rule.

Ref: sanskrit-lexicon/COLOGNE#249
