### PR TITLE
ci: fix readme-guard zero-count abort

### DIFF
--- a/.github/workflows/readme-guard.yml
+++ b/.github/workflows/readme-guard.yml
@@ -29,10 +29,10 @@ jobs:
             exit 0
           fi
           git fetch --no-tags --depth=1 origin "$base_ref"
-          base_begin=$(git show "origin/$base_ref:README.md" 2>/dev/null | grep -cF '<!-- BEGIN MANUAL:')
-          head_begin=$(grep -cF '<!-- BEGIN MANUAL:' README.md 2>/dev/null || echo 0)
-          base_end=$(git show "origin/$base_ref:README.md" 2>/dev/null | grep -cF '<!-- END MANUAL:')
-          head_end=$(grep -cF '<!-- END MANUAL:' README.md 2>/dev/null || echo 0)
+          base_begin=$(git show "origin/$base_ref:README.md" 2>/dev/null | grep -cF '<!-- BEGIN MANUAL:' || true)
+          head_begin=$(grep -cF '<!-- BEGIN MANUAL:' README.md 2>/dev/null || true)
+          base_end=$(git show "origin/$base_ref:README.md" 2>/dev/null | grep -cF '<!-- END MANUAL:' || true)
+          head_end=$(grep -cF '<!-- END MANUAL:' README.md 2>/dev/null || true)
           echo "base: BEGIN=$base_begin END=$base_end | head: BEGIN=$head_begin END=$head_end"
           fail=0
           if [ "$head_begin" -lt "$base_begin" ]; then


### PR DESCRIPTION
The `readme-guard.yml` guard aborted on a `set -e` + `grep -c`-exits-1-on-zero bug: the `base_begin`/`base_end` count lines lacked the exit-code guard, so on a zero-manual-block README the step died before any comparison — a false positive on every README PR here. All four count lines now end in `|| true` (grep still prints its 0; only the exit status is suppressed). The `head<base` protection is intact. Same fix already merged in csl-app, mw-dev, and sanskrit-lexicon.github.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)